### PR TITLE
Implement movie search UI

### DIFF
--- a/Final/Final/FinalApp.swift
+++ b/Final/Final/FinalApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct FinalApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            SearchView()
         }
     }
 }

--- a/Final/Final/Movie.swift
+++ b/Final/Final/Movie.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct Movie: Identifiable, Decodable {
+    let id: Int
+    let title: String
+    let overview: String
+    let posterPath: String?
+    let releaseDate: String?
+    let voteAverage: Double
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case overview
+        case posterPath = "poster_path"
+        case releaseDate = "release_date"
+        case voteAverage = "vote_average"
+    }
+
+    var posterURL: URL? {
+        guard let posterPath else { return nil }
+        return URL(string: "https://image.tmdb.org/t/p/w500\(posterPath)")
+    }
+}
+
+struct MovieResponse: Decodable {
+    let results: [Movie]
+}

--- a/Final/Final/MovieDetailView.swift
+++ b/Final/Final/MovieDetailView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct MovieDetailView: View {
+    let movie: Movie
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let url = movie.posterURL {
+                    AsyncImage(url: url) { image in
+                        image.resizable()
+                    } placeholder: {
+                        Color.gray
+                    }
+                    .frame(maxWidth: .infinity)
+                    .scaledToFit()
+                }
+                Text(movie.title)
+                    .font(.title)
+                    .padding(.bottom, 4)
+                Text(movie.overview)
+                    .font(.body)
+                if let date = movie.releaseDate {
+                    HStack {
+                        Text("Fecha de lanzamiento:")
+                        Spacer()
+                        Text(date)
+                    }
+                }
+                HStack {
+                    Text("Puntaje:")
+                    Spacer()
+                    Text(String(format: "%.1f", movie.voteAverage))
+                }
+            }
+            .padding()
+        }
+        .navigationTitle(movie.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    MovieDetailView(movie: Movie(id: 0, title: "Titulo", overview: "Descripcion", posterPath: nil, releaseDate: "2025-01-01", voteAverage: 0.0))
+}

--- a/Final/Final/SearchView.swift
+++ b/Final/Final/SearchView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct SearchView: View {
+    @StateObject private var viewModel = SearchViewModel()
+
+    var body: some View {
+        NavigationStack {
+            List(viewModel.movies) { movie in
+                NavigationLink(destination: MovieDetailView(movie: movie)) {
+                    HStack(alignment: .top, spacing: 8) {
+                        if let url = movie.posterURL {
+                            AsyncImage(url: url) { image in
+                                image.resizable()
+                            } placeholder: {
+                                Color.gray
+                            }
+                            .frame(width: 80, height: 120)
+                            .cornerRadius(6)
+                        }
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(movie.title)
+                                .font(.headline)
+                            Text(movie.overview)
+                                .font(.subheadline)
+                                .lineLimit(3)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle("Buscar Películas")
+            .searchable(text: $viewModel.query, prompt: "Nombre de la película")
+            .onSubmit(of: .search) {
+                Task { await viewModel.search() }
+            }
+        }
+    }
+}
+
+#Preview {
+    SearchView()
+}

--- a/Final/Final/SearchViewModel.swift
+++ b/Final/Final/SearchViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class SearchViewModel: ObservableObject {
+    @Published var query: String = ""
+    @Published var movies: [Movie] = []
+    @Published var isLoading: Bool = false
+
+    func search() async {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        isLoading = true
+        defer { isLoading = false }
+        let apiKey = "3cae426b920b29ed2fb1c0749f258325"
+        let encodedQuery = trimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        guard let url = URL(string: "https://api.themoviedb.org/3/search/movie?api_key=\(apiKey)&query=\(encodedQuery)") else {
+            return
+        }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let response = try JSONDecoder().decode(MovieResponse.self, from: data)
+            movies = response.results
+        } catch {
+            print("Search error: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SearchViewModel` for fetching from TheMovieDB API
- show search results in `SearchView`
- add `MovieDetailView` for selected movie
- wire new views to app entry in `FinalApp`
- define `Movie` model for decoding API responses

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68785e0a49988332a03acbd77794b729